### PR TITLE
feat: deploy service — git clone, Docker build, container start, rollback

### DIFF
--- a/app/lib/deployer.server.ts
+++ b/app/lib/deployer.server.ts
@@ -1,0 +1,212 @@
+import { randomUUID } from "crypto";
+import { execSync } from "child_process";
+import { mkdtempSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { db } from "./db.server";
+import { deployments, services, envVars } from "../../drizzle/schema";
+import { eq, and } from "drizzle-orm";
+import * as docker from "./docker.server";
+
+export type DeployLog = (line: string) => void;
+
+export async function deploy(
+  serviceId: string,
+  onLog: DeployLog = () => {},
+): Promise<string> {
+  const service = db
+    .select()
+    .from(services)
+    .where(eq(services.id, serviceId))
+    .get();
+  if (!service) throw new Error("Service not found");
+
+  const deployId = randomUUID();
+
+  db.insert(deployments)
+    .values({
+      id: deployId,
+      serviceId,
+      status: "building",
+      createdAt: new Date(),
+    })
+    .run();
+
+  try {
+    // 1. Clone repo
+    onLog("Cloning repository...\n");
+    const workDir = mkdtempSync(join(tmpdir(), "myrailway-build-"));
+
+    if (service.repoUrl) {
+      execSync(
+        `git clone --depth=1 --branch=${service.branch || "main"} ${service.repoUrl} .`,
+        { cwd: workDir, stdio: "pipe" },
+      );
+
+      const commitSha = execSync("git rev-parse HEAD", { cwd: workDir })
+        .toString()
+        .trim();
+      const commitMessage = execSync("git log -1 --pretty=%B", {
+        cwd: workDir,
+      })
+        .toString()
+        .trim();
+
+      db.update(deployments)
+        .set({ commitSha, commitMessage })
+        .where(eq(deployments.id, deployId))
+        .run();
+
+      onLog(`Checked out ${commitSha.slice(0, 7)}: ${commitMessage}\n`);
+    }
+
+    // 2. Build Docker image
+    const imageTag = `myrailway/${service.name}:${deployId.slice(0, 8)}`;
+    onLog("Building Docker image...\n");
+
+    const dockerfile = service.dockerfilePath || "Dockerfile";
+    if (!existsSync(join(workDir, dockerfile))) {
+      throw new Error(`Dockerfile not found at ${dockerfile}`);
+    }
+
+    await docker.buildImage(workDir, imageTag, dockerfile, onLog);
+
+    db.update(deployments)
+      .set({ status: "deploying", imageTag })
+      .where(eq(deployments.id, deployId))
+      .run();
+
+    onLog("Image built successfully.\n");
+
+    // 3. Gather env vars
+    const vars = db
+      .select()
+      .from(envVars)
+      .where(eq(envVars.serviceId, serviceId))
+      .all();
+    const envMap: Record<string, string> = {};
+    for (const v of vars) {
+      envMap[v.key] = v.value;
+    }
+
+    // 4. Stop previous active deployment
+    const prevDeploy = db
+      .select()
+      .from(deployments)
+      .where(
+        and(
+          eq(deployments.serviceId, serviceId),
+          eq(deployments.status, "active"),
+        ),
+      )
+      .get();
+
+    if (prevDeploy?.containerId) {
+      onLog("Stopping previous deployment...\n");
+      await docker.stopContainer(prevDeploy.containerId);
+      db.update(deployments)
+        .set({ status: "rolled_back" })
+        .where(eq(deployments.id, prevDeploy.id))
+        .run();
+    }
+
+    // 5. Start new container
+    onLog("Starting container...\n");
+    const containerName = `myrailway-${service.name}-${deployId.slice(0, 8)}`;
+    const containerId = await docker.createAndStartContainer({
+      image: imageTag,
+      name: containerName,
+      env: envMap,
+      port: service.port ?? undefined,
+    });
+
+    db.update(deployments)
+      .set({ status: "active", containerId, finishedAt: new Date() })
+      .where(eq(deployments.id, deployId))
+      .run();
+
+    onLog(`Deployment ${deployId.slice(0, 8)} is live!\n`);
+
+    return deployId;
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    db.update(deployments)
+      .set({ status: "failed", buildLog: message, finishedAt: new Date() })
+      .where(eq(deployments.id, deployId))
+      .run();
+
+    onLog(`Deploy failed: ${message}\n`);
+    throw error;
+  }
+}
+
+export async function rollback(
+  serviceId: string,
+  targetDeployId: string,
+): Promise<string> {
+  const target = db
+    .select()
+    .from(deployments)
+    .where(
+      and(
+        eq(deployments.id, targetDeployId),
+        eq(deployments.serviceId, serviceId),
+      ),
+    )
+    .get();
+
+  if (!target?.imageTag) throw new Error("Cannot rollback: no image tag");
+
+  // Stop current active deployment
+  const current = db
+    .select()
+    .from(deployments)
+    .where(
+      and(
+        eq(deployments.serviceId, serviceId),
+        eq(deployments.status, "active"),
+      ),
+    )
+    .get();
+
+  if (current?.containerId) {
+    await docker.stopContainer(current.containerId);
+    db.update(deployments)
+      .set({ status: "rolled_back" })
+      .where(eq(deployments.id, current.id))
+      .run();
+  }
+
+  // Gather env vars
+  const vars = db
+    .select()
+    .from(envVars)
+    .where(eq(envVars.serviceId, serviceId))
+    .all();
+  const envMap: Record<string, string> = {};
+  for (const v of vars) {
+    envMap[v.key] = v.value;
+  }
+
+  // Restart from target image
+  const service = db
+    .select()
+    .from(services)
+    .where(eq(services.id, serviceId))
+    .get()!;
+  const containerName = `myrailway-${service.name}-rollback-${Date.now()}`;
+
+  const containerId = await docker.createAndStartContainer({
+    image: target.imageTag,
+    name: containerName,
+    env: envMap,
+    port: service.port ?? undefined,
+  });
+
+  db.update(deployments)
+    .set({ status: "active", containerId })
+    .where(eq(deployments.id, targetDeployId))
+    .run();
+
+  return targetDeployId;
+}

--- a/tests/deployer.server.test.ts
+++ b/tests/deployer.server.test.ts
@@ -1,0 +1,517 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock Docker module
+vi.mock("~/lib/docker.server", () => ({
+  buildImage: vi.fn().mockResolvedValue("myrailway/test-svc:abcd1234"),
+  createAndStartContainer: vi.fn().mockResolvedValue("container-new-123"),
+  stopContainer: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock child_process.execSync for git operations
+vi.mock("child_process", () => ({
+  execSync: vi.fn((cmd: string) => {
+    if (cmd.startsWith("git clone")) return Buffer.from("");
+    if (cmd === "git rev-parse HEAD") return Buffer.from("abc1234def5678\n");
+    if (cmd === "git log -1 --pretty=%B")
+      return Buffer.from("feat: initial commit\n");
+    return Buffer.from("");
+  }),
+}));
+
+// Mock fs for temp dir and Dockerfile detection
+vi.mock("fs", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    mkdtempSync: vi.fn(() => "/tmp/myrailway-build-xyz"),
+    existsSync: vi.fn(() => true),
+  };
+});
+
+// Mock the db module with an in-memory SQLite database
+vi.mock("~/lib/db.server", async () => {
+  const Database = (await import("better-sqlite3")).default;
+  const { drizzle } = await import("drizzle-orm/better-sqlite3");
+  const schema = await import("../drizzle/schema");
+
+  const sqlite = new Database(":memory:");
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS users (
+      id TEXT PRIMARY KEY,
+      email TEXT NOT NULL UNIQUE,
+      name TEXT NOT NULL,
+      password_hash TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS projects (
+      id TEXT PRIMARY KEY,
+      user_id TEXT NOT NULL,
+      name TEXT NOT NULL,
+      description TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS services (
+      id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL,
+      name TEXT NOT NULL,
+      type TEXT NOT NULL,
+      repo_url TEXT,
+      branch TEXT DEFAULT 'main',
+      dockerfile_path TEXT DEFAULT 'Dockerfile',
+      port INTEGER,
+      replicas INTEGER DEFAULT 1,
+      created_at INTEGER NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS deployments (
+      id TEXT PRIMARY KEY,
+      service_id TEXT NOT NULL,
+      status TEXT NOT NULL,
+      commit_sha TEXT,
+      commit_message TEXT,
+      image_tag TEXT,
+      container_id TEXT,
+      build_log TEXT,
+      created_at INTEGER NOT NULL,
+      finished_at INTEGER
+    );
+    CREATE TABLE IF NOT EXISTS env_vars (
+      id TEXT PRIMARY KEY,
+      service_id TEXT NOT NULL,
+      environment_id TEXT,
+      key TEXT NOT NULL,
+      value TEXT NOT NULL,
+      is_secret INTEGER DEFAULT 0
+    );
+  `);
+
+  return { db: drizzle(sqlite, { schema }) };
+});
+
+import { db } from "~/lib/db.server";
+import {
+  services,
+  deployments,
+  envVars,
+  projects,
+  users,
+} from "../drizzle/schema";
+import * as dockerMock from "~/lib/docker.server";
+import { execSync } from "child_process";
+import { existsSync } from "fs";
+
+// Import the module under test
+const { deploy, rollback } = await import("~/lib/deployer.server");
+
+// Helper to seed a service
+function seedService(overrides: Partial<typeof services.$inferInsert> = {}) {
+  const userId = "user-1";
+  const projectId = "project-1";
+  const serviceId = overrides.id ?? "service-1";
+
+  // Ensure user & project exist (ignore duplicates)
+  try {
+    db.insert(users)
+      .values({
+        id: userId,
+        email: "test@test.com",
+        name: "Test",
+        passwordHash: "hash",
+        createdAt: new Date(),
+      })
+      .run();
+  } catch {
+    /* already exists */
+  }
+  try {
+    db.insert(projects)
+      .values({
+        id: projectId,
+        userId,
+        name: "Test Project",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .run();
+  } catch {
+    /* already exists */
+  }
+
+  db.insert(services)
+    .values({
+      id: serviceId,
+      projectId,
+      name: "test-svc",
+      type: "web",
+      repoUrl: "https://github.com/test/repo.git",
+      branch: "main",
+      dockerfilePath: "Dockerfile",
+      port: 3000,
+      createdAt: new Date(),
+      ...overrides,
+    })
+    .run();
+
+  return serviceId;
+}
+
+beforeEach(() => {
+  // Clear tables between tests
+  db.delete(deployments).run();
+  db.delete(envVars).run();
+  db.delete(services).run();
+  db.delete(projects).run();
+  db.delete(users).run();
+
+  // Reset mocks
+  vi.clearAllMocks();
+});
+
+describe("deploy", () => {
+  it("creates a deployment record with building status", async () => {
+    const serviceId = seedService();
+    const deployId = await deploy(serviceId);
+
+    const dep = db.select().from(deployments).all();
+    expect(dep.length).toBe(1);
+    expect(dep[0]!.id).toBe(deployId);
+    expect(dep[0]!.serviceId).toBe(serviceId);
+    // Final status should be active (it transitions through building → deploying → active)
+    expect(dep[0]!.status).toBe("active");
+  });
+
+  it("clones the repo using git clone --depth=1", async () => {
+    const serviceId = seedService();
+    await deploy(serviceId);
+
+    expect(execSync).toHaveBeenCalledWith(
+      expect.stringContaining("git clone --depth=1"),
+      expect.objectContaining({ cwd: "/tmp/myrailway-build-xyz" }),
+    );
+  });
+
+  it("extracts commit SHA and message from git", async () => {
+    const serviceId = seedService();
+    const deployId = await deploy(serviceId);
+
+    const dep = db.select().from(deployments).all();
+    expect(dep[0]!.commitSha).toBe("abc1234def5678");
+    expect(dep[0]!.commitMessage).toBe("feat: initial commit");
+  });
+
+  it("builds Docker image with correct tag", async () => {
+    const serviceId = seedService();
+    const deployId = await deploy(serviceId);
+
+    expect(dockerMock.buildImage).toHaveBeenCalledWith(
+      "/tmp/myrailway-build-xyz",
+      expect.stringMatching(/^myrailway\/test-svc:/),
+      "Dockerfile",
+      expect.any(Function),
+    );
+  });
+
+  it("stores the image tag on the deployment record", async () => {
+    const serviceId = seedService();
+    await deploy(serviceId);
+
+    const dep = db.select().from(deployments).all();
+    expect(dep[0]!.imageTag).toMatch(/^myrailway\/test-svc:/);
+  });
+
+  it("passes env vars to the container", async () => {
+    const serviceId = seedService();
+    db.insert(envVars)
+      .values([
+        {
+          id: "env-1",
+          serviceId,
+          key: "DATABASE_URL",
+          value: "postgres://localhost/db",
+        },
+        { id: "env-2", serviceId, key: "PORT", value: "3000" },
+      ])
+      .run();
+
+    await deploy(serviceId);
+
+    expect(dockerMock.createAndStartContainer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: { DATABASE_URL: "postgres://localhost/db", PORT: "3000" },
+        port: 3000,
+      }),
+    );
+  });
+
+  it("stops previous active deployment before starting new one", async () => {
+    const serviceId = seedService();
+
+    // Insert a previous active deployment
+    db.insert(deployments)
+      .values({
+        id: "prev-deploy",
+        serviceId,
+        status: "active",
+        containerId: "old-container-id",
+        createdAt: new Date(),
+      })
+      .run();
+
+    await deploy(serviceId);
+
+    expect(dockerMock.stopContainer).toHaveBeenCalledWith("old-container-id");
+
+    // Previous deployment should be marked as rolled_back
+    const prev = db.select().from(deployments).all();
+    const prevDep = prev.find((d) => d.id === "prev-deploy");
+    expect(prevDep!.status).toBe("rolled_back");
+  });
+
+  it("starts new container and marks deployment active", async () => {
+    const serviceId = seedService();
+    const deployId = await deploy(serviceId);
+
+    expect(dockerMock.createAndStartContainer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        image: expect.stringMatching(/^myrailway\/test-svc:/),
+        name: expect.stringContaining("myrailway-test-svc-"),
+      }),
+    );
+
+    const dep = db.select().from(deployments).all();
+    expect(dep[0]!.status).toBe("active");
+    expect(dep[0]!.containerId).toBe("container-new-123");
+    expect(dep[0]!.finishedAt).toBeTruthy();
+  });
+
+  it("records failed status when build fails", async () => {
+    const serviceId = seedService();
+    vi.mocked(dockerMock.buildImage).mockRejectedValueOnce(
+      new Error("Build failed: syntax error"),
+    );
+
+    await expect(deploy(serviceId)).rejects.toThrow("Build failed");
+
+    const dep = db.select().from(deployments).all();
+    expect(dep[0]!.status).toBe("failed");
+    expect(dep[0]!.buildLog).toContain("Build failed");
+    expect(dep[0]!.finishedAt).toBeTruthy();
+  });
+
+  it("throws when service not found", async () => {
+    await expect(deploy("nonexistent-service")).rejects.toThrow(
+      "Service not found",
+    );
+  });
+
+  it("throws when Dockerfile not found", async () => {
+    const serviceId = seedService();
+    vi.mocked(existsSync).mockReturnValueOnce(false);
+
+    await expect(deploy(serviceId)).rejects.toThrow("Dockerfile not found");
+
+    const dep = db.select().from(deployments).all();
+    expect(dep[0]!.status).toBe("failed");
+  });
+
+  it("calls onLog callback with progress messages", async () => {
+    const serviceId = seedService();
+    const logs: string[] = [];
+    await deploy(serviceId, (line) => logs.push(line));
+
+    expect(logs.some((l) => l.includes("Cloning repository"))).toBe(true);
+    expect(logs.some((l) => l.includes("Building Docker image"))).toBe(true);
+    expect(logs.some((l) => l.includes("Starting container"))).toBe(true);
+    expect(logs.some((l) => l.includes("is live"))).toBe(true);
+  });
+
+  it("captures build logs in deployment record on failure", async () => {
+    const serviceId = seedService();
+    vi.mocked(dockerMock.buildImage).mockRejectedValueOnce(
+      new Error("npm ERR! missing dependency"),
+    );
+
+    await expect(deploy(serviceId)).rejects.toThrow();
+
+    const dep = db.select().from(deployments).all();
+    expect(dep[0]!.buildLog).toContain("npm ERR! missing dependency");
+  });
+
+  it("skips git clone when service has no repoUrl", async () => {
+    const serviceId = seedService({ repoUrl: null });
+    await deploy(serviceId);
+
+    expect(execSync).not.toHaveBeenCalledWith(
+      expect.stringContaining("git clone"),
+      expect.anything(),
+    );
+  });
+});
+
+describe("rollback", () => {
+  it("stops current active deployment", async () => {
+    const serviceId = seedService();
+
+    // Current active deployment
+    db.insert(deployments)
+      .values({
+        id: "current-deploy",
+        serviceId,
+        status: "active",
+        containerId: "current-container",
+        imageTag: "myrailway/test-svc:current",
+        createdAt: new Date(),
+      })
+      .run();
+
+    // Target deployment to rollback to
+    db.insert(deployments)
+      .values({
+        id: "target-deploy",
+        serviceId,
+        status: "rolled_back",
+        imageTag: "myrailway/test-svc:target",
+        createdAt: new Date(),
+      })
+      .run();
+
+    await rollback(serviceId, "target-deploy");
+
+    expect(dockerMock.stopContainer).toHaveBeenCalledWith("current-container");
+  });
+
+  it("marks current deployment as rolled_back", async () => {
+    const serviceId = seedService();
+
+    db.insert(deployments)
+      .values({
+        id: "current-deploy",
+        serviceId,
+        status: "active",
+        containerId: "current-container",
+        imageTag: "myrailway/test-svc:current",
+        createdAt: new Date(),
+      })
+      .run();
+
+    db.insert(deployments)
+      .values({
+        id: "target-deploy",
+        serviceId,
+        status: "rolled_back",
+        imageTag: "myrailway/test-svc:target",
+        createdAt: new Date(),
+      })
+      .run();
+
+    await rollback(serviceId, "target-deploy");
+
+    const current = db
+      .select()
+      .from(deployments)
+      .all()
+      .find((d) => d.id === "current-deploy");
+    expect(current!.status).toBe("rolled_back");
+  });
+
+  it("restarts container from target image and marks it active", async () => {
+    const serviceId = seedService();
+
+    db.insert(deployments)
+      .values({
+        id: "target-deploy",
+        serviceId,
+        status: "rolled_back",
+        imageTag: "myrailway/test-svc:target",
+        createdAt: new Date(),
+      })
+      .run();
+
+    await rollback(serviceId, "target-deploy");
+
+    expect(dockerMock.createAndStartContainer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        image: "myrailway/test-svc:target",
+        port: 3000,
+      }),
+    );
+
+    const target = db
+      .select()
+      .from(deployments)
+      .all()
+      .find((d) => d.id === "target-deploy");
+    expect(target!.status).toBe("active");
+    expect(target!.containerId).toBe("container-new-123");
+  });
+
+  it("passes env vars to the rolled-back container", async () => {
+    const serviceId = seedService();
+
+    db.insert(envVars)
+      .values({ id: "env-1", serviceId, key: "API_KEY", value: "secret123" })
+      .run();
+
+    db.insert(deployments)
+      .values({
+        id: "target-deploy",
+        serviceId,
+        status: "rolled_back",
+        imageTag: "myrailway/test-svc:target",
+        createdAt: new Date(),
+      })
+      .run();
+
+    await rollback(serviceId, "target-deploy");
+
+    expect(dockerMock.createAndStartContainer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: { API_KEY: "secret123" },
+      }),
+    );
+  });
+
+  it("throws when target deployment has no image tag", async () => {
+    const serviceId = seedService();
+
+    db.insert(deployments)
+      .values({
+        id: "no-image-deploy",
+        serviceId,
+        status: "failed",
+        createdAt: new Date(),
+      })
+      .run();
+
+    await expect(rollback(serviceId, "no-image-deploy")).rejects.toThrow(
+      "Cannot rollback: no image tag",
+    );
+  });
+
+  it("throws when target deployment not found", async () => {
+    const serviceId = seedService();
+
+    await expect(rollback(serviceId, "nonexistent")).rejects.toThrow(
+      "Cannot rollback",
+    );
+  });
+
+  it("works when there is no current active deployment", async () => {
+    const serviceId = seedService();
+
+    db.insert(deployments)
+      .values({
+        id: "target-deploy",
+        serviceId,
+        status: "failed",
+        imageTag: "myrailway/test-svc:target",
+        createdAt: new Date(),
+      })
+      .run();
+
+    await rollback(serviceId, "target-deploy");
+
+    expect(dockerMock.stopContainer).not.toHaveBeenCalled();
+    expect(dockerMock.createAndStartContainer).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Implements `app/lib/deployer.server.ts` with full deploy pipeline: git clone → Dockerfile detection → Docker build (with log streaming) → stop previous container → start new container with env vars + networking → mark active
- Implements `rollback()` to restart from a previous deployment's image
- Tracks deployments in DB with status transitions: `building` → `deploying` → `active` (or `failed`)
- 21 unit tests covering all deploy and rollback flows, error handling, and edge cases

## Test plan
- [x] `deploy()` creates deployment record with correct status transitions
- [x] `deploy()` clones repo, extracts commit info, builds Docker image
- [x] `deploy()` stops previous active deployment before starting new one
- [x] `deploy()` passes env vars to container
- [x] `deploy()` records failed status with error message on failure
- [x] `deploy()` throws on missing service or missing Dockerfile
- [x] `deploy()` streams progress via onLog callback
- [x] `deploy()` handles services without a repo URL
- [x] `rollback()` stops current active deployment and restarts from target image
- [x] `rollback()` passes env vars to rolled-back container
- [x] `rollback()` throws on missing image tag or nonexistent target
- [x] All 28 tests pass (21 deployer + 7 auth)

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)